### PR TITLE
Update Linux commands article for hacker audience

### DIFF
--- a/BlogPortal/Linux_Command.html
+++ b/BlogPortal/Linux_Command.html
@@ -5,10 +5,10 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>15 Essential Linux Commands for Beginners | CSC Blog</title>
+  <title>15 Essential Linux Commands for Hackers | CSC Blog</title>
   <meta name="description" content="A comprehensive walkthrough of the top Linux with practical examples.">
-  <meta name="keywords" content="Linux Commands for Beginners, penetration testing, security vulnerabilities">
-  <meta property="og:title" content="15 Essential Linux Commands for Beginners">
+  <meta name="keywords" content="Linux Commands for Hackers, penetration testing, security vulnerabilities">
+  <meta property="og:title" content="15 Essential Linux Commands for Hackers">
   <meta property="og:description" content="Learn about the 15 Essential Linux Commands with practical examples.">
   
   <link rel="stylesheet" href="../assets/css/style.css">
@@ -253,10 +253,6 @@ expected data.</p>
 <li>Avoid <code>sudo</code>: Don’t run as root unless needed.</li>
 
 </ul>
-
-
-
-
           <!-- Article Tags -->
           <div class="article-tags">
             <h4>Tags</h4>


### PR DESCRIPTION
Changed page title, keywords, and Open Graph title from 'Beginners' to 'Hackers' to better target the intended audience. No content changes to the command list or examples.