### PR TITLE
Rename “Groups” to “Teams” across all site pages for consistent navigation

### DIFF
--- a/BlogPortal/owasp-top-10-guide.html
+++ b/BlogPortal/owasp-top-10-guide.html
@@ -42,7 +42,7 @@
         </li>
         <li><a href="../events.html"><span class="navbar-slash">|</span>Events</a></li>
         <li><a href="../gallery.html"><span class="navbar-slash">|</span>Gallery</a></li>
-        <li><a href="../groups.html"><span class="navbar-slash">|</span>Groups</a></li>
+        <li><a href="../groups.html"><span class="navbar-slash">|</span>Teams</a></li>
         <li><a href="../resources.html"><span class="navbar-slash">|</span>Resources</a></li>
         <li><a href="../sponsors.html"><span class="navbar-slash">|</span>Sponsors</a></li>
         <li class="dropdown">

--- a/CTF.html
+++ b/CTF.html
@@ -196,7 +196,7 @@
           <a href="gallery.html"><span class="navbar-slash">|</span>Gallery</a>
         </li>
         <li>
-          <a href="groups.html"><span class="navbar-slash">|</span>Groups</a>
+          <a href="groups.html"><span class="navbar-slash">|</span>Teams</a>
         </li>
         <li>
           <a href="resources.html"><span class="navbar-slash">|</span>Resources</a>

--- a/CTFMonthly.html
+++ b/CTFMonthly.html
@@ -69,7 +69,7 @@
           <a href="gallery.html"><span class="navbar-slash">|</span>Gallery</a>
         </li>
         <li>
-          <a href="groups.html"><span class="navbar-slash">|</span>Groups</a>
+          <a href="groups.html"><span class="navbar-slash">|</span>Teams</a>
         </li>
         <li>
           <a href="resources.html"><span class="navbar-slash">|</span>Resources</a>

--- a/CTFWeekly.html
+++ b/CTFWeekly.html
@@ -69,7 +69,7 @@
           <a href="gallery.html"><span class="navbar-slash">|</span>Gallery</a>
         </li>
         <li>
-          <a href="groups.html"><span class="navbar-slash">|</span>Groups</a>
+          <a href="groups.html"><span class="navbar-slash">|</span>Teams</a>
         </li>
         <li>
           <a href="resources.html"><span class="navbar-slash">|</span>Resources</a>

--- a/CTFWriteups.html
+++ b/CTFWriteups.html
@@ -165,7 +165,7 @@
           <a href="gallery.html"><span class="navbar-slash">|</span>Gallery</a>
         </li>
         <li>
-          <a href="groups.html"><span class="navbar-slash">|</span>Groups</a>
+          <a href="groups.html"><span class="navbar-slash">|</span>Teams</a>
         </li>
         <li>
           <a href="resources.html"><span class="navbar-slash">|</span>Resources</a>

--- a/CertificateGenerator/certificate-generator.html
+++ b/CertificateGenerator/certificate-generator.html
@@ -78,7 +78,7 @@
                     <a href="../gallery.html"><span class="navbar-slash">|</span>Gallery</a>
                 </li>
                 <li>
-                    <a href="../groups.html"><span class="navbar-slash">|</span>Groups</a>
+                    <a href="../groups.html"><span class="navbar-slash">|</span>Teams</a>
                 </li>
                 <li>
                     <a href="../resources.html"><span class="navbar-slash">|</span>Resources</a>

--- a/MemberShip.html
+++ b/MemberShip.html
@@ -195,7 +195,7 @@
           <a href="gallery.html"><span class="navbar-slash">|</span>Gallery</a>
         </li>
         <li>
-          <a href="groups.html"><span class="navbar-slash">|</span>Groups</a>
+          <a href="groups.html"><span class="navbar-slash">|</span>Teams</a>
         </li>
         <li>
           <a href="resources.html"><span class="navbar-slash">|</span>Resources</a>

--- a/NewsPortal/News.html
+++ b/NewsPortal/News.html
@@ -52,7 +52,7 @@
           <a href="../gallery.html"><span class="navbar-slash">|</span>Gallery</a>
         </li>
         <li>
-          <a href="../groups.html"><span class="navbar-slash">|</span>Groups</a>
+          <a href="../groups.html"><span class="navbar-slash">|</span>Teams</a>
         </li>
         <li>
           <a href="../resources.html"><span class="navbar-slash">|</span>Resources</a>

--- a/NewsPortal/chairman-announcement.html
+++ b/NewsPortal/chairman-announcement.html
@@ -95,7 +95,7 @@
           <a href="../gallery.html"><span class="navbar-slash">|</span>Gallery</a>
         </li>
         <li>
-          <a href="../groups.html"><span class="navbar-slash">|</span>Groups</a>
+          <a href="../groups.html"><span class="navbar-slash">|</span>Teams</a>
         </li>
         <li>
           <a href="../resources.html"><span class="navbar-slash">|</span>Resources</a>

--- a/NewsPortal/ctf-night.html
+++ b/NewsPortal/ctf-night.html
@@ -95,7 +95,7 @@
           <a href="../gallery.html"><span class="navbar-slash">|</span>Gallery</a>
         </li>
         <li>
-          <a href="../groups.html"><span class="navbar-slash">|</span>Groups</a>
+          <a href="../groups.html"><span class="navbar-slash">|</span>Teams</a>
         </li>
         <li>
           <a href="../resources.html"><span class="navbar-slash">|</span>Resources</a>

--- a/NewsPortal/recruitment-news.html
+++ b/NewsPortal/recruitment-news.html
@@ -95,7 +95,7 @@
           <a href="../gallery.html"><span class="navbar-slash">|</span>Gallery</a>
         </li>
         <li>
-          <a href="../groups.html"><span class="navbar-slash">|</span>Groups</a>
+          <a href="../groups.html"><span class="navbar-slash">|</span>Teams</a>
         </li>
         <li>
           <a href="../resources.html"><span class="navbar-slash">|</span>Resources</a>

--- a/NewsPortal/store-opening-news.html
+++ b/NewsPortal/store-opening-news.html
@@ -94,7 +94,7 @@
           <a href="../gallery.html"><span class="navbar-slash">|</span>Gallery</a>
         </li>
         <li>
-          <a href="../groups.html"><span class="navbar-slash">|</span>Groups</a>
+          <a href="../groups.html"><span class="navbar-slash">|</span>Teams</a>
         </li>
         <li>
           <a href="../resources.html"><span class="navbar-slash">|</span>Resources</a>

--- a/about.html
+++ b/about.html
@@ -195,7 +195,7 @@
           <a href="gallery.html"><span class="navbar-slash">|</span>Gallery</a>
         </li>
         <li>
-          <a href="groups.html"><span class="navbar-slash">|</span>Groups</a>
+          <a href="groups.html"><span class="navbar-slash">|</span>Teams</a>
         </li>
         <li>
           <a href="resources.html"><span class="navbar-slash">|</span>Resources</a>

--- a/advisor.html
+++ b/advisor.html
@@ -195,7 +195,7 @@
           <a href="gallery.html"><span class="navbar-slash">|</span>Gallery</a>
         </li>
         <li>
-          <a href="groups.html"><span class="navbar-slash">|</span>Groups</a>
+          <a href="groups.html"><span class="navbar-slash">|</span>Teams</a>
         </li>
         <li>
           <a href="resources.html"><span class="navbar-slash">|</span>Resources</a>

--- a/blog.html
+++ b/blog.html
@@ -63,7 +63,7 @@
         </li>
         <li><a href="events.html"><span class="navbar-slash">|</span>Events</a></li>
         <li><a href="gallery.html"><span class="navbar-slash">|</span>Gallery</a></li>
-        <li><a href="groups.html"><span class="navbar-slash">|</span>Groups</a></li>
+        <li><a href="groups.html"><span class="navbar-slash">|</span>Teams</a></li>
         <li><a href="resources.html"><span class="navbar-slash">|</span>Resources</a></li>
         <li><a href="sponsors.html"><span class="navbar-slash">|</span>Sponsors</a></li>
         <li class="dropdown">

--- a/cart.html
+++ b/cart.html
@@ -116,7 +116,7 @@
           <a href="gallery.html"><span class="navbar-slash">|</span>Gallery</a>
         </li>
         <li>
-          <a href="groups.html"><span class="navbar-slash">|</span>Groups</a>
+          <a href="groups.html"><span class="navbar-slash">|</span>Teams</a>
         </li>
         <li>
           <a href="resources.html"><span class="navbar-slash">|</span>Resources</a>

--- a/events.html
+++ b/events.html
@@ -194,7 +194,7 @@
           <a href="gallery.html"><span class="navbar-slash">|</span>Gallery</a>
         </li>
         <li>
-          <a href="groups.html"><span class="navbar-slash">|</span>Groups</a>
+          <a href="groups.html"><span class="navbar-slash">|</span>Teams</a>
         </li>
         <li>
           <a href="resources.html"><span class="navbar-slash">|</span>Resources</a>

--- a/gallery.html
+++ b/gallery.html
@@ -195,7 +195,7 @@
           <a href="gallery.html" class="active-nav-link"><span class="navbar-slash">|</span>Gallery</a>
         </li>
         <li>
-          <a href="groups.html"><span class="navbar-slash">|</span>Groups</a>
+          <a href="groups.html"><span class="navbar-slash">|</span>Teams</a>
         </li>
         <li>
           <a href="resources.html"><span class="navbar-slash">|</span>Resources</a>

--- a/groups.html
+++ b/groups.html
@@ -195,7 +195,7 @@
           <a href="gallery.html"><span class="navbar-slash">|</span>Gallery</a>
         </li>
         <li>
-          <a href="groups.html" class="active-nav-link"><span class="navbar-slash">|</span>Groups</a>
+          <a href="groups.html" class="active-nav-link"><span class="navbar-slash">|</span>Teams</a>
         </li>
         <li>
           <a href="resources.html"><span class="navbar-slash">|</span>Resources</a>
@@ -311,7 +311,7 @@
               competitions.
               <br><br>
               <div style="text-align: center; ">Team Members
-                <p>Shova | Kanon | Nahid </p></div>
+                <p>Shova | Kanon | Seam </p></div>
             </div>
           </div>
             <hr>

--- a/index.html
+++ b/index.html
@@ -195,7 +195,7 @@
           <a href="gallery.html"><span class="navbar-slash">|</span>Gallery</a>
         </li>
         <li>
-          <a href="groups.html"><span class="navbar-slash">|</span>Groups</a>
+          <a href="groups.html"><span class="navbar-slash">|</span>Teams</a>
         </li>
         <li>
           <a href="resources.html"><span class="navbar-slash">|</span>Resources</a>

--- a/logo.html
+++ b/logo.html
@@ -658,7 +658,7 @@
           <a href="gallery.html"><span class="navbar-slash">|</span>Gallery</a>
         </li>
         <li>
-          <a href="groups.html"><span class="navbar-slash">|</span>Groups</a>
+          <a href="groups.html"><span class="navbar-slash">|</span>Teams</a>
         </li>
         <li>
           <a href="resources.html"><span class="navbar-slash">|</span>Resources</a>

--- a/recruitment.html
+++ b/recruitment.html
@@ -316,7 +316,7 @@
           <a href="gallery.html"><span class="navbar-slash">|</span>Gallery</a>
         </li>
         <li>
-          <a href="groups.html"><span class="navbar-slash">|</span>Groups</a>
+          <a href="groups.html"><span class="navbar-slash">|</span>Teams</a>
         </li>
         <li>
           <a href="resources.html"><span class="navbar-slash">|</span>Resources</a>

--- a/resources.html
+++ b/resources.html
@@ -190,7 +190,7 @@
           <a href="gallery.html"><span class="navbar-slash">|</span>Gallery</a>
         </li>
         <li>
-          <a href="groups.html"><span class="navbar-slash">|</span>Groups</a>
+          <a href="groups.html"><span class="navbar-slash">|</span>Teams</a>
         </li>
         <li>
           <a href="resources.html" class="active-nav-link"><span class="navbar-slash">|</span>Resources</a>

--- a/sponsors.html
+++ b/sponsors.html
@@ -83,7 +83,7 @@
           <a href="gallery.html"><span class="navbar-slash">|</span>Gallery</a>
         </li>
         <li>
-          <a href="groups.html"><span class="navbar-slash">|</span>Groups</a>
+          <a href="groups.html"><span class="navbar-slash">|</span>Teams</a>
         </li>
         <li>
           <a href="resources.html"><span class="navbar-slash">|</span>Resources</a>

--- a/store.html
+++ b/store.html
@@ -114,7 +114,7 @@
           <a href="gallery.html"><span class="navbar-slash">|</span>Gallery</a>
         </li>
         <li>
-          <a href="groups.html"><span class="navbar-slash">|</span>Groups</a>
+          <a href="groups.html"><span class="navbar-slash">|</span>Teams</a>
         </li>
         <li>
           <a href="resources.html"><span class="navbar-slash">|</span>Resources</a>


### PR DESCRIPTION
This update standardizes the website navigation by renaming all instances of “Groups” to “Teams” across every relevant HTML page. The change ensures consistent terminology and improves user clarity throughout the Cyber Security Club website.

Modified Files:

- BlogPortal/owasp-top-10-guide.html

- CertificateGenerator/certificate-generator.html

- NewsPortal/News.html

- NewsPortal/chairman-announcement.html

- NewsPortal/ctf-night.html

- NewsPortal/recruitment-news.html

- NewsPortal/store-opening-news.html

- CTF.html

- CTFMonthly.html

- CTFWeekly.html

- CTFWriteups.html

- MemberShip.html

- about.html

- advisor.html

- blog.html

- cart.html

- events.html

- gallery.html

- groups.html

- index.html

- logo.html

- recruitment.html

- resources.html

- sponsors.html

- store.html